### PR TITLE
Acceleration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![Paper](https://img.shields.io/badge/paper-%09arXiv%3A2003.12673-yellow.svg)](https://arxiv.org/abs/2206.08928)
 
 ## UPDATES:
+* [December 4th 2023] Accelerated implementations of ring deconvolution.
+  * Now run deconvolution up to 15x faster!
+  * Run batched ring convolution up to 100x faster!
 * [August 30th 2023] Introducing RDMPY v1!
   * Official PyPI package to follow shortly.
   * Includes a new deep deblurring model, DeepRD (try it out with our pretrained models).

--- a/rdmpy/_src/polar_transform.py
+++ b/rdmpy/_src/polar_transform.py
@@ -312,3 +312,299 @@ def polar2img(
     )
     cartImage = cartImage.squeeze()
     return cartImage
+
+
+######## Batched & Accelerated #######
+
+
+def getCartesianPointsTorch(r, theta, center):
+    """
+    Convert list of polar points to cartesian points
+
+    Parameters
+    ----------
+    r : torch.tensor
+        List of radii
+
+    theta : torch.tensor
+        List of angles
+
+    center : tuple
+        Center of the image, (x,y) format
+
+    Returns
+    -------
+    x : torch.tensor
+        List of x coordinates
+
+    y : torch.tensor
+        List of y coordinates
+
+    """
+    x = r * torch.cos(theta) + center[0]
+    y = r * torch.sin(theta) + center[1]
+    return x, y
+
+
+def getPolarPointsTorch(x, y, center):
+    """
+    Convert list of cartesian points to polar points in pytorch
+
+    Parameters
+    ----------
+    x : torch.tensor
+        List of x coordinates
+
+    y : torch.tensor
+        List of y coordinates
+
+    center : tuple
+        Center of the image (x,y) format
+
+    Returns
+    -------
+    r : torch.tensor
+        List of radii
+
+    theta : torch.tensor
+        List of angles
+
+    """
+    cX, cY = x - center[0], y - center[1]
+
+    r = torch.sqrt(cX**2 + cY**2)
+
+    theta = torch.arctan2(cY, cX)
+
+    # Make range of theta 0 -> 2pi instead of -pi -> pi
+    # According to StackOverflow, this is the fastest method:
+    # https://stackoverflow.com/questions/37358016/numpy-converting-range-of-angles-from-pi-pi-to-0-2pi
+    theta = torch.where(theta < 0, theta + 2 * torch.pi, theta)
+
+    return r, theta
+
+
+def batchimg2polar(
+    img,
+    numRadii=None,
+    finalRadius=None,
+    initialAngle=0,
+    finalAngle=np.pi * 2,
+    center=None,
+    border="constant",
+):
+    """
+    Converts batch of cartesian images to polar image.
+    Expects multichan images, but chan & batch dimension can be 1.
+
+    Parameters
+    ----------
+    img : torch.Tensor
+        Image to be converted. Should be (B, C, N, N)
+
+    numRadii : int, optional
+        Number of radii to use. If None, the image sidelength is used.
+
+    finalRadius : float, optional
+        Final radius to use. If None, the image diagonal is used.
+
+    initialAngle : float, optional
+        Initial angle to use in radians. Default is 0.
+
+    finalAngle : float, optional
+        Final angle to use in radians. Default is 2pi.
+
+    center : tuple, optional
+        Center of the image (x,y) format. Default is the center of the image.
+
+    border : str, optional
+        How to handle borders. Options are 'constant', 'reflect', 'replicate',
+        'circular', 'zeros'. Default is 'constant'.
+
+    Returns
+    -------
+    polarImage : torch.Tensor
+        Polar image will be (B, numAngles, numRadii, C)
+
+    """
+    if center is None:
+        center = (np.array(img.shape[-1:-3:-1]) - 1) / 2.0
+
+    if finalRadius is None:
+        corners = np.array([[0, 0], [0, 1], [1, 0], [1, 1]]) * img.shape[-2:]
+        radii, _ = getPolarPoints(corners[:, 1], corners[:, 0], center)
+        finalRadius = radii.max()
+        finalRadius = (img.shape[2] / 2) * np.sqrt(2)
+
+    maxSize = np.max(img.shape[2:])
+    if numRadii is None:
+        numRadii = maxSize
+
+    initialAngle = np.pi / 4
+    finalAngle = 2 * np.pi + np.pi / 4
+
+    if maxSize > 700:
+        numAngles = int(
+            2 * np.max(img.shape[2:]) * ((finalAngle - initialAngle) / (2 * np.pi))
+        )
+    else:
+        numAngles = int(
+            4 * np.max(img.shape[2:]) * ((finalAngle - initialAngle) / (2 * np.pi))
+        )
+
+    # get radii and angles for generating point sampling
+    radii = np.sqrt(2) * (
+        np.linspace(0, (img.shape[2] / 2), numRadii, endpoint=False, retstep=False)
+        + 0.5
+    )
+    theta = np.linspace(initialAngle, finalAngle, numAngles, endpoint=False)
+
+    # convert to tensors to accelerate point sampling
+    theta, r = torch.meshgrid(
+        torch.tensor(theta, device=img.device), torch.tensor(radii, device=img.device)
+    )
+    center = torch.tensor(center, device=img.device)
+    xCartesian, yCartesian = getCartesianPointsTorch(r, theta, center)
+
+    pad = 3
+    if border == "constant":
+        # Pad image by 3 pixels and then offset all of the desired coordinates by 3
+        img = fun.pad(img, (pad, pad, pad, pad), "replicate")
+        xCartesian += pad
+        yCartesian += pad
+
+    gx = 2.0 * (xCartesian / (img.shape[3] - 1)) - 1.0
+    gy = 2.0 * (yCartesian / (img.shape[2] - 1)) - 1.0
+    desiredCoords = torch.stack((gx, gy), 2)
+    desiredCoords = desiredCoords.unsqueeze(0).repeat(
+        img.shape[0], *(1,) * len(desiredCoords.shape)
+    )
+
+    polarImage = fun.grid_sample(
+        img.float(),
+        desiredCoords.float(),
+        padding_mode="zeros",
+        mode=INTERP_TYPE,
+        align_corners=True,
+    )
+
+    return polarImage
+
+
+def batchpolar2img(
+    img,
+    imageSize=None,
+    initialRadius=0,
+    finalRadius=None,
+    initialAngle=0,
+    finalAngle=np.pi * 2,
+    center=None,
+    border="constant",
+):
+    """
+    Converts batch of polar images to cartesian image.
+    Expects multichan images, but chan & batch dimension can be 1.
+
+    Parameters
+    ----------
+    img : torch.Tensor
+        Polar image to be converted. Should be (B, C, A, R) where A is angles and R is radii.
+
+    imageSize : tuple, optional
+        Size of the image to be returned. If None, the image is assumed to be (B, C, R, R).
+
+    initialRadius : float, optional
+        Initial radius to use. Default is 0.
+
+    finalRadius : float, optional
+        Final radius to use. If None, the image diagonal is used.
+
+    initialAngle : float, optional
+        Initial angle to use in radians. Default is 0.
+
+    finalAngle : float, optional
+        Final angle to use in radians. Default is 2pi.
+
+    center : tuple, optional
+        Center of the image (x,y) format. Default is the center of the image.
+
+    border : str, optional
+        How to handle borders. Options are 'constant', 'reflect', 'replicate',
+
+    Returns
+    -------
+    cartImage : torch.Tensor
+        Cartesian image, will be imageSize
+
+    """
+    imageSize = (img.shape[-1], img.shape[-1])
+    if center is None:
+        center = ((imageSize[-2] - 1) / 2.0, (imageSize[-1] - 1) / 2.0)
+
+    initialAngle = np.pi / 4
+    finalAngle = 2 * np.pi + np.pi / 4
+
+    if finalRadius is None:
+        corners = np.array([[0, 0], [0, 1], [1, 0], [1, 1]]) * imageSize[-2:]
+        radii, _ = getPolarPoints(corners[:, 1], corners[:, 0], center)
+
+    # This is used to scale the result of the radius to get the Cartesian value
+    radii = np.sqrt(2) * (
+        np.linspace(
+            0, (imageSize[-2] / 2), img.shape[-1], endpoint=False, retstep=False
+        )
+        + 0.5
+    )
+    initialRadius = radii[0]
+    finalRadius = radii[-1]
+    scaleRadius = img.shape[-1] / (finalRadius - initialRadius)
+
+    # This is used to scale the result of the angle to get the  Cartesian value
+    scaleAngle = img.shape[-2] / (finalAngle - initialAngle)
+
+    # Get list of cartesian x and y coordinate and create a 2D create of the coordinates
+    xs = torch.arange(0, imageSize[-1], device=img.device)
+    ys = torch.arange(0, imageSize[-2], device=img.device)
+    y, x = torch.meshgrid(ys, xs)
+
+    # Take cartesian grid and convert to polar coordinates
+    r, theta = getPolarPointsTorch(x, y, center)
+
+    # Offset the radius by the initial source radius
+    r = r - initialRadius
+
+    # Offset the theta angle by the initial source angle
+    # The theta values may go past 2pi, so they are modulo 2pi.
+    # Note: This assumes initial source angle is positive
+    theta = torch.remainder(theta - initialAngle + 2 * np.pi, 2 * np.pi)
+
+    # Scale the radius using scale factor
+    r = r * scaleRadius
+
+    # Scale the angle from radians to pixels using scale factor
+    theta = theta * scaleAngle
+
+    pad = 3
+
+    if border == "constant":
+        # Pad image by 3 pixels and then offset all of the desired coordinates by 3
+        img = fun.pad(img, (pad, pad, pad, pad), "replicate")
+        r += pad
+        theta += pad
+
+    gr = 2.0 * (r / (img.shape[3] - 1)) - 1.0
+    gtheta = 2.0 * (theta / (img.shape[2] - 1)) - 1.0
+    desiredCoords = torch.stack((gr, gtheta), 2)
+    desiredCoords = desiredCoords.unsqueeze(0).repeat(
+        img.shape[0], *(1,) * len(desiredCoords.shape)
+    )
+
+    cartImage = fun.grid_sample(
+        img.float(),
+        desiredCoords.float(),
+        padding_mode="zeros",
+        mode=INTERP_TYPE,
+        align_corners=True,
+    )
+
+    return cartImage

--- a/rdmpy/_src/polar_transform.py
+++ b/rdmpy/_src/polar_transform.py
@@ -461,7 +461,9 @@ def batchimg2polar(
 
     # convert to tensors to accelerate point sampling
     theta, r = torch.meshgrid(
-        torch.tensor(theta, device=img.device), torch.tensor(radii, device=img.device)
+        torch.tensor(theta, device=img.device),
+        torch.tensor(radii, device=img.device),
+        indexing="ij",
     )
     center = torch.tensor(center, device=img.device)
     xCartesian, yCartesian = getCartesianPointsTorch(r, theta, center)
@@ -565,7 +567,7 @@ def batchpolar2img(
     # Get list of cartesian x and y coordinate and create a 2D create of the coordinates
     xs = torch.arange(0, imageSize[-1], device=img.device)
     ys = torch.arange(0, imageSize[-2], device=img.device)
-    y, x = torch.meshgrid(ys, xs)
+    y, x = torch.meshgrid(ys, xs, indexing="ij")
 
     # Take cartesian grid and convert to polar coordinates
     r, theta = getPolarPointsTorch(x, y, center)

--- a/rdmpy/blur.py
+++ b/rdmpy/blur.py
@@ -48,6 +48,8 @@ def ring_convolve(
         obj = torch.tensor(obj).float()
     if obj.device is not device:
         obj = obj.to(device)
+    if not len(obj.shape) == 2 and obj.shape[0] == obj.shape[1]:
+        raise AssertionError(f"Object of shape {obj.shape} must be 2d square image")
 
     # infer info from the PSF roft
     num_radii = psf_roft.shape[0]
@@ -104,7 +106,6 @@ def batch_ring_convolve(obj, psf_roft, device=torch.device("cpu")):
         The ring convolution of the object with the PSF stack. Will be (B,C,N,N).
 
     """
-
     if not torch.is_tensor(obj):
         obj = torch.tensor(obj)  # .float()
     if obj.device is not device:

--- a/rdmpy/tests/README.md
+++ b/rdmpy/tests/README.md
@@ -1,0 +1,28 @@
+# Testing
+
+Testing suites using python unittest. Currently implemented:
+
+- [batched convolution numerical & speed comparison](test_batch_ring_conv.py)
+- [batched deconvolution numerical & speed comparison](test_batch_ring_deconv.py)
+
+To run all tests, run the following command from the root project directory:
+
+```sh
+python -m unittest rdmpy/tests/*.py
+```
+NOTE: timing here uses *random PSF tensors*, which are harder to optimize than real, sparse PSF data. Speedup with real PSF data are likely to be orders of magnitude greater.
+
+Current outputs:
+```
+2023-12-04 19:41:35,909 - INFO - Unbatched convolution deconvolution time: 0.061296 seconds per image on cuda:0
+2023-12-04 19:41:37,564 - INFO - Batched convolution deconvolution time: 0.016551 seconds per image on cuda:0
+100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 300/300 [00:40<00:00,  7.43it/s]
+2023-12-04 19:42:22,317 - INFO - Unbatched-conv deconvolution time: 40.483006 seconds per image on cuda:0
+100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 300/300 [00:03<00:00, 94.58it/s]
+2023-12-04 19:41:41,834 - INFO - Batched-conv deconvolution time: 3.268919 seconds per image on cuda:0
+.
+----------------------------------------------------------------------
+Ran 2 tests in 56.421s
+
+OK
+```

--- a/rdmpy/tests/test_batch_ring_conv.py
+++ b/rdmpy/tests/test_batch_ring_conv.py
@@ -1,23 +1,46 @@
-import unittest
-from ..blur import ring_convolve, batch_ring_convolve
+import logging
+import numpy as np
+import time
 import torch
+import unittest
+
+from ..blur import ring_convolve, batch_ring_convolve
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
 
 
 class TestRingConvolveFunctions(unittest.TestCase):
     def test_batch_ring_convolve(self):
         """Test that batched and normal ring convolution are numerically close"""
-        img_stack = torch.rand((3, 3, 256, 256))
-        psfs = torch.rand((256, 513, 256))
+        device = "cpu"
+        if torch.cuda.is_available():
+            device = "cuda:0"
 
-        batched = batch_ring_convolve(img_stack, psfs, device="cpu")
+        img_stack = torch.rand((10, 10, 384, 384)).to(device)
+        psfs = torch.rand((384, 769, 384)).to(device)
+
+        t1 = time.time()
         unbatched = torch.zeros_like(img_stack)
-        for i in range(3):
-            for j in range(3):
-                unbatched[i, j] = ring_convolve(img_stack[i, j], psfs, device="cpu")
-
-        self.assertTrue(
-            torch.all(torch.isclose(batched, unbatched, rtol=0.0001)).item()
+        for i in range(img_stack.shape[0]):
+            for j in range(img_stack.shape[1]):
+                unbatched[i, j] = ring_convolve(
+                    img_stack[i, j], psfs, device=device, verbose=False
+                )
+        t2 = time.time()
+        logging.info(
+            f"Unbatched convolution deconvolution time: {(t2 - t1)/100:2f} seconds per image on {device}"
         )
+
+        t1 = time.time()
+        batched = batch_ring_convolve(img_stack, psfs, device=device)
+        t2 = time.time()
+        logging.info(
+            f"Batched convolution deconvolution time: {(t2 - t1)/100:2f} seconds per image on {device}"
+        )
+
+        self.assertTrue(torch.allclose(batched, unbatched, 0.0001))
 
 
 if __name__ == "__main__":

--- a/rdmpy/tests/test_batch_ring_conv.py
+++ b/rdmpy/tests/test_batch_ring_conv.py
@@ -1,0 +1,24 @@
+import unittest
+from ..blur import ring_convolve, batch_ring_convolve
+import torch
+
+
+class TestRingConvolveFunctions(unittest.TestCase):
+    def test_batch_ring_convolve(self):
+        """Test that batched and normal ring convolution are numerically close"""
+        img_stack = torch.rand((3, 3, 256, 256))
+        psfs = torch.rand((256, 513, 256))
+
+        batched = batch_ring_convolve(img_stack, psfs, device="cpu")
+        unbatched = torch.zeros_like(img_stack)
+        for i in range(3):
+            for j in range(3):
+                unbatched[i, j] = ring_convolve(img_stack[i, j], psfs, device="cpu")
+
+        self.assertTrue(
+            torch.all(torch.isclose(batched, unbatched, rtol=0.0001)).item()
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rdmpy/tests/test_batch_ring_deconv.py
+++ b/rdmpy/tests/test_batch_ring_deconv.py
@@ -1,0 +1,48 @@
+import logging
+import numpy as np
+import time
+import torch
+import unittest
+
+from ..deblur import ring_deconvolve
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
+
+class TestRingConvolveFunctions(unittest.TestCase):
+    def test_batch_ring_deconvolve(self):
+        """Test that lri deconvolution with batched and normal ring convolution are numerically close"""
+        device = "cpu"
+        if torch.cuda.is_available():
+            device = "cuda:0"
+
+        img_stack = torch.rand((384, 384)).to(device)
+        psfs = torch.rand((384, 769, 384)).to(device)
+
+        t1 = time.time()
+        using_unbatched_conv = ring_deconvolve(
+            img_stack, psfs, use_batch_conv=False, device=device
+        )
+        t2 = time.time()
+        logging.info(
+            f"Unbatched-conv deconvolution time: {t2 - t1:2f} seconds per image on {device}"
+        )
+
+        t1 = time.time()
+        using_batched_conv = ring_deconvolve(
+            img_stack, psfs, use_batch_conv=True, device=device
+        )
+        t2 = time.time()
+        logging.info(
+            f"Batched-conv deconvolution time: {t2 - t1:2f} seconds per image on {device}"
+        )
+
+        self.assertTrue(
+            np.max(np.abs(using_batched_conv - using_unbatched_conv)) < 0.0003
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
PR for implementations of accelerated and batched ring convolution and deconvolution. See unit tests showing numerical closeness at [tests](rdmpy/tests/README.md). 

**NOTE:** There is a very small numerical difference that I've found (error upper bound of `10e-4 * mean(input)` difference), which I think has to do with the way that PyTorch's  `F.meshgrid` samples across batches, so I've left the original implementations and created a toggling flag `ring_deconvolve(*args, use_batch_conv=bool)` for using the batched implementations.